### PR TITLE
Add support for updating the `updated_at` column when deleting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 group :development do
   gem "sqlite3", :platforms => [:ruby]
   gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
+  gem "timecop"
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ If your column type is a `string`, you can also specify which value to use when 
 
 If your column type is a `boolean`, it is possible to specify `allow_nulls` option which is `true` by default. When set to `false`, entities that have `false` value in this column will be considered not deleted, and those which have `true` will be considered deleted. When `true` everything that has a not-null value will be considered deleted.
 
+Additionally, you can specify whether or not you want the `updated_at` column updated on delete. This option accepts a boolean and defaults to `false`:
+
+- `:touch => false`
+
+Setting it to `true` will set `updated_at` to `Time.now` when the record is soft-deleted.
+
 ### Filtering
 
 If a record is deleted by ActsAsParanoid, it won't be retrieved when accessing the database.

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "minitest", ">= 4.0", "<= 6.0"
+  spec.add_development_dependency "timecop"
 end

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -19,12 +19,13 @@ module ActsAsParanoid
 
     class_attribute :paranoid_configuration, :paranoid_column_reference
 
-    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes }
+    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes, touch: false }
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
     self.paranoid_configuration.merge!({ :allow_nulls => true }) if options[:column_type] == "boolean"
     self.paranoid_configuration.merge!(options) # user options
 
     raise ArgumentError, "'time', 'boolean' or 'string' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'boolean', 'string'].include? paranoid_configuration[:column_type]
+    raise ArgumentError, "touch must be either true or false" unless [true, false].include? paranoid_configuration[:touch]
 
     self.paranoid_column_reference = "#{self.table_name}.#{paranoid_configuration[:column]}"
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'timecop'
 
 class ParanoidTest < ParanoidBaseTest
   def test_paranoid?
@@ -37,6 +38,25 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 3, ParanoidTime.with_deleted.count
     assert_equal 3, ParanoidBoolean.with_deleted.count
     assert_equal 1, ParanoidString.with_deleted.count
+  end
+
+  def test_fake_removal_with_touch
+    future = Time.now.utc + 60
+    tree = ParanoidTree.create(name: 'SillyTree')
+    Timecop.freeze(future) do
+      tree.destroy
+    end
+    assert_equal future, tree.updated_at.utc
+    assert_equal future, tree.reload.updated_at.utc
+  end
+
+  def test_fake_removal_without_touch
+    future = Time.now.utc + 60
+    paranoid_time = ParanoidTime.first
+    Timecop.freeze(future) do
+      paranoid_time.destroy
+    end
+    assert_not_equal paranoid_time.updated_at.utc, future
   end
 
   def test_real_removal

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -446,7 +446,7 @@ class ParanoidForest < ActiveRecord::Base
 end
 
 class ParanoidTree < ActiveRecord::Base
-  acts_as_paranoid
+  acts_as_paranoid(touch: true)
   belongs_to :paranoid_forest
   validates_presence_of :name
 end


### PR DESCRIPTION
This adds a `touch` configuration option, which accepts a boolean and defaults to false. When true, `acts_as_paranoid` will update the `updated_at` column with the current time on soft-delete. This should allow deletes to be picked up by Redshift ETL going forward, once we update the appropriate models in `petition_service` and `user_service` to use the option.

@change/anchor @mdimas  @quaelin  @change/datascience 